### PR TITLE
Adding support for multipart content-type header.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ console.assert(contentType.toString() === "text/html;charset=windows-1252");
 console.assert(contentType.isHTML() === true);
 console.assert(contentType.isXML() === false);
 console.assert(contentType.isText() === true);
+console.assert(contentType.isMultiPart() === false);
+
+console.assert(contentType.isValid() === true);
 ```
 
 Note how parsing will lowercase the type, subtype, and parameter name tokens (but not parameter values).
@@ -50,7 +53,7 @@ Both of these will lowercase the keys.
 - `isHTML()`: returns true if this instance's MIME type is [the HTML MIME type](https://html.spec.whatwg.org/multipage/infrastructure.html#html-mime-type), `"text/html"`
 - `isXML()`: returns true if this instance's MIME type is [an XML MIME type](https://html.spec.whatwg.org/multipage/infrastructure.html#xml-mime-type)
 - `isText()`: returns true if this instance's top-level media type is `"text"`
-
+- `isMultiPart()`: returns true if the instance's top-level media type is `"multipart"`
 ### Serialization
 
 - `toString()` will return a canonicalized representation of the content-type, re-built from the parsed components

--- a/lib/content-type-parser.js
+++ b/lib/content-type-parser.js
@@ -6,6 +6,19 @@ const parameterValueRegexp = /^(.*?)=(.*)$/;
 const quotedStringRegexp = /"(?:[\t \x21\x23-\x5B\x5D-\x7E\x80-\xFF]|(?:\\[\t \x21-\x7E\x80-\xFF]))*"/;
 const qescRegExp = /\\([\t \x21-\x7E\x80-\xFF])/g;
 const quoteRegExp = /([\\"])/g;
+const multipartValidSubtypes = [
+  "mixed",
+  "digest",
+  "message",
+  "alternative",
+  "related",
+  "report",
+  "signed",
+  "encrypted",
+  "form-data",
+  "mixed-replace",
+  "byteranges"
+];
 
 function qstring(val) {
   if (tokenRegexp.test(val)) {
@@ -44,8 +57,18 @@ class ContentType {
   isHTML() {
     return this.subtype === "html" && this.type === "text";
   }
+  isMultipart() {
+    return this.subtype === "form-data" && this.type === "multipart";
+  }
   isText() {
     return this.type === "text";
+  }
+  isValid() {
+    if (this.isMultipart()) {
+      return this.parameterList.map(v => v.key === "boundary").includes(true) &&
+      multipartValidSubtypes.includes(this.subtype.toLowerCase());
+    }
+    return this.isXML() || this.isHTML() || this.isText();
   }
   toString() {
     return this.type + "/" + this.subtype +

--- a/test/tests.js
+++ b/test/tests.js
@@ -140,6 +140,47 @@ describe("application/xhtml+xml", () => {
   });
 });
 
+describe("multipart/form-data;boundary=something", () => {
+  const contentType = contentTypeParser("multipart/form-data;boundary=something");
+
+  it("should set the properties correctly", () => {
+    assert.strictEqual(contentType.type, "multipart");
+    assert.strictEqual(contentType.subtype, "form-data");
+    assert.strictEqual(contentType.parameterList.length, 1);
+  });
+
+  it("should response to the type tests correctly", () => {
+    assert.strictEqual(contentType.isHTML(), false);
+    assert.strictEqual(contentType.isXML(), false);
+    assert.strictEqual(contentType.isText(), false);
+    assert.strictEqual(contentType.isMultipart(), true);
+  });
+
+  it("should serialize correctly", () => {
+    assert.strictEqual(contentType.toString(), "multipart/form-data;boundary=something");
+  });
+
+  it("should respond to sets correctly", () => {
+    contentType.set("boundary", "data");
+    assert.strictEqual(contentType.get("boundary"), "data");
+    assert.strictEqual(contentType.toString(), "multipart/form-data;boundary=data");
+  });
+
+  it("should validate required boundary parameter", () => {
+    assert.strictEqual(contentType.isValid(), true);
+  });
+
+  it("should invalidate if required boundary parameter is missing", () => {
+    const invalidContentType = contentTypeParser("multipart/form-data;something=data");
+    assert.strictEqual(invalidContentType.isValid(), false);
+  });
+
+  it("should invalidate for not supported subtype", () => {
+    const invalidContentType = contentTypeParser("multipart/foo-bar;boundary=data");
+    assert.strictEqual(invalidContentType.isValid(), false);
+  });
+});
+
 const xml = [
   "application/xml",
   "text/xml",
@@ -163,6 +204,7 @@ describe("foo/xml", () => {
   it("should not respond as XML (or HTML)", () => {
     assert.strictEqual(contentType.isHTML(), false);
     assert.strictEqual(contentType.isXML(), false);
+    assert.strictEqual(contentType.isValid(), false);
   });
 });
 


### PR DESCRIPTION
Adding support to detect `multipart` content type. Based on https://en.wikipedia.org/wiki/MIME#Multipart_messages

- Adding `isValid` property to `contentType`.
- Adding `isMultipart` property to `contentType`.