### PR TITLE
Rename `content-type-parser` to `whatwg-mimetype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This package will parse [MIME types](https://mimesniff.spec.whatwg.org/#understanding-mime-types) into a structured format, which can then be manipulated and serialized:
 
 ```js
-const MIMEType = require("content-type-parser");
+const MIMEType = require("whatwg-mimetype");
 
 const mimeType = new MIMEType(`Text/HTML;Charset="utf-8"`);
 
@@ -89,8 +89,8 @@ mimeType.parameters.set("@", "x");
 If you want primitives on which to build your own API, you can get direct access to the parsing and serialization algorithms as follows:
 
 ```js
-const parse = require("content-type-parser/parser");
-const serialize = require("content-type-parser/serialize");
+const parse = require("whatwg-mimetype/parser");
+const serialize = require("whatwg-mimetype/serialize");
 ```
 
 `parse(string)` returns an object containing the `type` and `subtype` strings, plus `parameters`, which is a `Map`. This is roughly our equivalent of the spec's [MIME type record](https://mimesniff.spec.whatwg.org/#mime-type). If parsing fails, it instead returns `null`.


### PR DESCRIPTION
Update examples with new package name