### PR TITLE
Add .isJS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ This package's main module's default export is a class, `MIMEType`. Its construc
 - `toString()` serializes the MIME type to a string
 - `isHTML()`: returns true if this instance represents [a HTML MIME type](https://mimesniff.spec.whatwg.org/#html-mime-type)
 - `isXML()`: returns true if this instance represents [an XML MIME type](https://mimesniff.spec.whatwg.org/#xml-mime-type)
+- `isJS({ allowParameters })`: returns true if this instance represents [a JavaScript MIME type](https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type); `allowParameters` can be set to true to allow arbitrary parameters, instead of their presence causing the method to return `false`
 
-_Note: the `isHTML()` and `isXML()` methods are speculative, and may be removed or changed in future major versions. See [whatwg/mimesniff#48](https://github.com/whatwg/mimesniff/issues/48) for brainstorming in this area. Currently we implement these mainly because they are useful in jsdom._
+_Note: the `isHTML()`, `isXML()`, and `isJS()` methods are speculative, and may be removed or changed in future major versions. See [whatwg/mimesniff#48](https://github.com/whatwg/mimesniff/issues/48) for brainstorming in this area. Currently we implement these mainly because they are useful in jsdom._
 
 ## `MIMETypeParameters` API
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This package's main module's default export is a class, `MIMEType`. Its construc
 - `toString()` serializes the MIME type to a string
 - `isHTML()`: returns true if this instance represents [a HTML MIME type](https://mimesniff.spec.whatwg.org/#html-mime-type)
 - `isXML()`: returns true if this instance represents [an XML MIME type](https://mimesniff.spec.whatwg.org/#xml-mime-type)
-- `isJS({ allowParameters })`: returns true if this instance represents [a JavaScript MIME type](https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type); `allowParameters` can be set to true to allow arbitrary parameters, instead of their presence causing the method to return `false`
+- `isJavaScript({ allowParameters })`: returns true if this instance represents [a JavaScript MIME type](https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type); `allowParameters` can be set to true to allow arbitrary parameters, instead of their presence causing the method to return `false`
 
 _Note: the `isHTML()`, `isXML()`, and `isJS()` methods are speculative, and may be removed or changed in future major versions. See [whatwg/mimesniff#48](https://github.com/whatwg/mimesniff/issues/48) for brainstorming in this area. Currently we implement these mainly because they are useful in jsdom._
 

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -84,7 +84,7 @@ module.exports = class MIMEType {
           case "livescript":
           case "x-ecmascript":
           case "x-javascript": {
-            return check();
+            return allowParameters || this._parameters.size === 0;
           }
           default: {
             return false;
@@ -97,7 +97,7 @@ module.exports = class MIMEType {
           case "javascript":
           case "x-ecmascript":
           case "x-javascript": {
-            return check();
+            return allowParameters || this._parameters.size === 0;
           }
           default: {
             return false;
@@ -107,10 +107,6 @@ module.exports = class MIMEType {
       default: {
         return false;
       }
-    }
-
-    function check() {
-      return allowParameters || this._parameters.size === 0;
     }
   }
   isXML() {

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -68,7 +68,13 @@ module.exports = class MIMEType {
     return serialize(this);
   }
 
-  isJS() {
+  isJS({ allowParameters = false } = {}) {
+    const check = () => {
+      if (allowParameters) {
+        return true;
+      }
+      return this._parameters.size === 0;
+    };
     switch (this._type) {
       case "text": {
         switch (this._subtype) {
@@ -84,7 +90,7 @@ module.exports = class MIMEType {
           case "livescript":
           case "x-ecmascript":
           case "x-javascript": {
-            return true;
+            return check();
           }
           default: {
             return false;
@@ -97,7 +103,7 @@ module.exports = class MIMEType {
           case "javascript":
           case "x-ecmascript":
           case "x-javascript": {
-            return true;
+            return check();
           }
           default: {
             return false;

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -69,12 +69,6 @@ module.exports = class MIMEType {
   }
 
   isJS({ allowParameters = false } = {}) {
-    const check = () => {
-      if (allowParameters) {
-        return true;
-      }
-      return this._parameters.size === 0;
-    };
     switch (this._type) {
       case "text": {
         switch (this._subtype) {
@@ -113,6 +107,10 @@ module.exports = class MIMEType {
       default: {
         return false;
       }
+    }
+
+    function check() {
+      return allowParameters || this._parameters.size === 0;
     }
   }
   isXML() {

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -68,7 +68,7 @@ module.exports = class MIMEType {
     return serialize(this);
   }
 
-  isJS({ allowParameters = false } = {}) {
+  isJavaScript({ allowParameters = false } = {}) {
     switch (this._type) {
       case "text": {
         switch (this._subtype) {

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -70,10 +70,8 @@ module.exports = class MIMEType {
 
   isJS() {
     switch (this._type) {
-      default: return false;
-      case "text":
+      case "text": {
         switch (this._subtype) {
-          default: return false;
           case "ecmascript":
           case "javascript":
           case "javascript1.0":
@@ -85,18 +83,30 @@ module.exports = class MIMEType {
           case "jscript":
           case "livescript":
           case "x-ecmascript":
-          case "x-javascript":
+          case "x-javascript": {
             return true;
+          }
+          default: {
+            return false;
+          }
         }
-      case "application":
+      }
+      case "application": {
         switch (this._subtype) {
-          default: return false;
           case "ecmascript":
           case "javascript":
           case "x-ecmascript":
-          case "x-javascript":
+          case "x-javascript": {
             return true;
+          }
+          default: {
+            return false;
+          }
         }
+      }
+      default: {
+        return false;
+      }
     }
   }
   isXML() {

--- a/lib/mime-type.js
+++ b/lib/mime-type.js
@@ -68,6 +68,37 @@ module.exports = class MIMEType {
     return serialize(this);
   }
 
+  isJS() {
+    switch (this._type) {
+      default: return false;
+      case "text":
+        switch (this._subtype) {
+          default: return false;
+          case "ecmascript":
+          case "javascript":
+          case "javascript1.0":
+          case "javascript1.1":
+          case "javascript1.2":
+          case "javascript1.3":
+          case "javascript1.4":
+          case "javascript1.5":
+          case "jscript":
+          case "livescript":
+          case "x-ecmascript":
+          case "x-javascript":
+            return true;
+        }
+      case "application":
+        switch (this._subtype) {
+          default: return false;
+          case "ecmascript":
+          case "javascript":
+          case "x-ecmascript":
+          case "x-javascript":
+            return true;
+        }
+    }
+  }
   isXML() {
     return (this._subtype === "xml" && (this._type === "text" || this._type === "application")) ||
            this._subtype.endsWith("+xml");

--- a/test/api.js
+++ b/test/api.js
@@ -192,22 +192,14 @@ describe("Group-testing functions", () => {
     expect((new MIMEType("text/javascript")).isJS()).toBe(true);
 
     expect((new MIMEType("text/javascript;charset=utf-8")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({
-      allowParameters: true
-    })).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({ allowParameters: true })).toBe(true);
     expect((new MIMEType("text/javascript;charset=utf-8")).isJS({})).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({
-      allowParameters: false
-    })).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({ allowParameters: false })).toBe(false);
 
     expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS({
-      allowParameters: true
-    })).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS({ allowParameters: true })).toBe(true);
 
     expect((new MIMEType("text/javascript;goal=module")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;goal=module")).isJS({
-      allowParameters: true
-    })).toBe(true);
+    expect((new MIMEType("text/javascript;goal=module")).isJS({ allowParameters: true })).toBe(true);
   });
 });

--- a/test/api.js
+++ b/test/api.js
@@ -171,4 +171,26 @@ describe("Group-testing functions", () => {
     expect((new MIMEType("application/html")).isXML()).toBe(false);
     expect((new MIMEType("application/xml+xhtml")).isXML()).toBe(false);
   });
+
+  test("isJS", () => {
+    expect((new MIMEType("application/ecmascript")).isJS()).toBe(true);
+    expect((new MIMEType("application/javascript")).isJS()).toBe(true);
+    expect((new MIMEType("application/x-ecmascript")).isJS()).toBe(true);
+    expect((new MIMEType("application/x-javascript")).isJS()).toBe(true);
+    expect((new MIMEType("text/ecmascript")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.0")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.1")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.2")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.3")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.4")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript1.5")).isJS()).toBe(true);
+    expect((new MIMEType("text/jscript")).isJS()).toBe(true);
+    expect((new MIMEType("text/livescript")).isJS()).toBe(true);
+    expect((new MIMEType("text/x-ecmascript")).isJS()).toBe(true);
+    expect((new MIMEType("text/x-javascript")).isJS()).toBe(true);
+
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript;goal=module")).isJS()).toBe(true);
+  });
 });

--- a/test/api.js
+++ b/test/api.js
@@ -172,34 +172,35 @@ describe("Group-testing functions", () => {
     expect((new MIMEType("application/xml+xhtml")).isXML()).toBe(false);
   });
 
-  test("isJS", () => {
-    expect((new MIMEType("application/ecmascript")).isJS()).toBe(true);
-    expect((new MIMEType("application/javascript")).isJS()).toBe(true);
-    expect((new MIMEType("application/x-ecmascript")).isJS()).toBe(true);
-    expect((new MIMEType("application/x-javascript")).isJS()).toBe(true);
-    expect((new MIMEType("text/ecmascript")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.0")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.1")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.2")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.3")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.4")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript1.5")).isJS()).toBe(true);
-    expect((new MIMEType("text/jscript")).isJS()).toBe(true);
-    expect((new MIMEType("text/livescript")).isJS()).toBe(true);
-    expect((new MIMEType("text/x-ecmascript")).isJS()).toBe(true);
-    expect((new MIMEType("text/x-javascript")).isJS()).toBe(true);
+  test("isJavaScript", () => {
+    expect((new MIMEType("application/ecmascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("application/javascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("application/x-ecmascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("application/x-javascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/ecmascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.0")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.1")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.2")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.3")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.4")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/javascript1.5")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/jscript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/livescript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/x-ecmascript")).isJavaScript()).toBe(true);
+    expect((new MIMEType("text/x-javascript")).isJavaScript()).toBe(true);
 
-    expect((new MIMEType("text/javascript")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript")).isJavaScript()).toBe(true);
 
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({ allowParameters: true })).toBe(true);
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({})).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({ allowParameters: false })).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJavaScript()).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJavaScript({ allowParameters: true })).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJavaScript({})).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJavaScript({ allowParameters: false })).toBe(false);
 
-    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS({ allowParameters: true })).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJavaScript()).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJavaScript({ allowParameters: true }))
+      .toBe(true);
 
-    expect((new MIMEType("text/javascript;goal=module")).isJS()).toBe(false);
-    expect((new MIMEType("text/javascript;goal=module")).isJS({ allowParameters: true })).toBe(true);
+    expect((new MIMEType("text/javascript;goal=module")).isJavaScript()).toBe(false);
+    expect((new MIMEType("text/javascript;goal=module")).isJavaScript({ allowParameters: true })).toBe(true);
   });
 });

--- a/test/api.js
+++ b/test/api.js
@@ -189,8 +189,25 @@ describe("Group-testing functions", () => {
     expect((new MIMEType("text/x-ecmascript")).isJS()).toBe(true);
     expect((new MIMEType("text/x-javascript")).isJS()).toBe(true);
 
-    expect((new MIMEType("text/javascript;charset=utf-8")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS()).toBe(true);
-    expect((new MIMEType("text/javascript;goal=module")).isJS()).toBe(true);
+    expect((new MIMEType("text/javascript")).isJS()).toBe(true);
+
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS()).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({
+      allowParameters: true
+    })).toBe(true);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({})).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8")).isJS({
+      allowParameters: false
+    })).toBe(false);
+
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS()).toBe(false);
+    expect((new MIMEType("text/javascript;charset=utf-8;goal=script")).isJS({
+      allowParameters: true
+    })).toBe(true);
+
+    expect((new MIMEType("text/javascript;goal=module")).isJS()).toBe(false);
+    expect((new MIMEType("text/javascript;goal=module")).isJS({
+      allowParameters: true
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
Not in MIME sniffing standard, but in https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages , unsure if it fits here but I assume so.